### PR TITLE
Addressed mishandling of starting time values, Issue #107

### DIFF
--- a/mtl/ast.py
+++ b/mtl/ast.py
@@ -42,7 +42,7 @@ def _neg(exp):
     return Neg(exp)
 
 
-def _eval(exp, trace, time=0, *, dt=0.1, quantitative=True):
+def _eval(exp, trace, time=False, *, dt=0.1, quantitative=True):
     from mtl import evaluator
     return evaluator.pointwise_sat(exp, dt)(trace, time, quantitative)
 

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -25,7 +25,11 @@ def to_signal(ts_mapping):
 def interp(sig, t, tag=None):
     # TODO: return function that interpolates the whole signal.
     sig = sig.project({tag})
-    key = sig.data.keys()[sig.data.bisect_right(t) - 1]
+    idx = sig.data.bisect_right(t) - 1
+    if idx<0:
+        return None
+    else:
+        key = sig.data.keys()[idx]
     return sig[key][tag]
 
 
@@ -60,6 +64,9 @@ def pointwise_sat(phi, dt=0.1):
         if t is None:
             res = [(t, v[phi]) for t, v in f(sig).items()]
             return res if quantitative else [((t, v > 0) for t, v in res)]
+
+        if t is False:
+            t = f(sig).items()[0][0]
 
         res = interp(f(sig), t, phi)
         return res if quantitative else res > 0


### PR DESCRIPTION
Addressed problem that initial signal times needed to be 0 to provide the correct answer. This was the result previously:

```
import mtl
data = {'b':[(0,1000),(2,900),(3,8000)],'a': [(1, 100), (2, 90), (3, 800)]}
phi=mtl.parse('a') 
phi(data)
# Output (WRONG): 800
```

With the new fix, the output is the "correct" answer: 100. The idea that this is "correct" could be the subject of some debate, though. This change assumes that, if no time argument is given for the evaluation, then the intention is that the robustness value **at the earliest time in the signal** should be provided. 
 
Note that this raises a question about how signals should be interpreted before the first time instant present in the signal. I am assuming that the signals are interpreted as piecewise-constant, right-continuous signals, with points of discontinuity at the times given in the signal. But then there is a question about what the signal is defined as (if it is defined) before the first instant. Based on examples where a Boolean formula is evaluated over some signals that are not defined, I am assuming that the undefined signals are treated as "don't cares". For example:

```
import mtl
data = {'b':[(0,1000),(2,900),(3,8000)],'a': [(1, 100), (2, 90), (3, 800)]}
phi=mtl.parse('(a&c)')
phi(data,time=None)
# Result: [(1, 100), (2, 90), (3, 800)]

phi=mtl.parse('(a|c)')
phi(data,time=None)
# Result: [(1, 100), (2, 90), (3, 800)]
```

Based on this, and assuming that the signals before the first time instant defined in the signal are treated as "don't care", the current fix seems to provide the correct answers.

