### PR TITLE
Fix negative time in signals following a timeshift

### DIFF
--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -150,7 +150,8 @@ def eval_mtl_next(phi, dt):
     f = eval_mtl(phi.arg, dt)
 
     def _eval(x):
-        return (f(x) << dt).retag({phi.arg: phi})
+        v = (f(x) << dt)
+        return v[max(v.start, 0):].retag({phi.arg: phi})
 
     return _eval
 

--- a/mtl/test_eval.py
+++ b/mtl/test_eval.py
@@ -11,3 +11,12 @@ def test_eval_regression_smoke1():
     }
     f2 = mtl.parse('(a U[0,3] b)')
     f2(d2, quantitative=False)
+
+
+def test_eval_regression_next_neg():
+    """From issue #219"""
+    d = {"a": [(0, False), (1, True)]}
+    f = mtl.parse("(a & (X (~a)))")
+    v = f(d, quantitative=False, dt=1, time=None)
+    assert not f(d, quantitative=False, dt=1)
+    assert min(t for t, _ in v) >= 0


### PR DESCRIPTION
Fix for issue #219 

- Force signals resulting from the evaluation of the next operator to start from at least 0 (an invariant checked upon creating the signal for evaluation).
- Add a small regression test on the expected value and timestamps.