### PR TITLE
Fix missing value on signal start after until

### DIFF
--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -150,7 +150,8 @@ def eval_mtl_next(phi, dt):
     f = eval_mtl(phi.arg, dt)
 
     def _eval(x):
-        return (f(x) << dt).retag({phi.arg: phi})
+        v = (f(x) << dt)
+        return v[max(v.start, 0):].retag({phi.arg: phi})
 
     return _eval
 

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -33,6 +33,11 @@ def interp(sig, t, tag=None):
     return sig[key][tag]
 
 
+def interp_all(sig, t, end=OO):
+    v = fn.map(lambda u: signal([(t, interp(sig, t, u))], t, end, u), sig.tags)
+    return reduce(op.__or__, v)
+
+
 def dense_compose(sig1, sig2, init=None):
     sig12 = sig1 | sig2
     tags = sig12.tags
@@ -110,6 +115,7 @@ def eval_mtl_until(phi, dt):
 
     def _eval(x):
         sig = dense_compose(f1(x), f2(x), init=-OO)
+        sig = sig | interp_all(sig, x.start, OO)  # Force valuation at start
         data = apply_weak_until(phi.arg1, phi.arg2, sig)
         return signal(data, x.start, OO, tag=phi)
 

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -135,6 +135,12 @@ def eval_mtl_g(phi, dt):
         tmp = f(x)
         assert b >= a
         if b > a:
+            # Force valuation at pivot points
+            if a < b < OO:
+                ts = fn.map(
+                    lambda t: interp_all(tmp, t - b - a + dt, tmp.end),
+                    tmp.times())
+                tmp = reduce(op.__or__, ts, tmp)[tmp.start:tmp.end]
             return tmp.rolling(a, b).map(_min, tag=phi)
 
         return tmp.retag({phi.arg: phi})

--- a/mtl/test_eval.py
+++ b/mtl/test_eval.py
@@ -11,3 +11,12 @@ def test_eval_regression_smoke1():
     }
     f2 = mtl.parse('(a U[0,3] b)')
     f2(d2, quantitative=False)
+
+
+def test_eval_regression_next_neg():
+    """From issue #219"""
+    d = {"a": [(0, False), (1, True)]}
+    f = mtl.parse("(a & (X (~a)))")
+    v = f(d, quantitative=False, dt=1, time=None)
+    assert not f(d, quantitative=False, dt=1)
+    assert min(t for t, _ in v) >= 0

--- a/mtl/test_eval.py
+++ b/mtl/test_eval.py
@@ -42,3 +42,27 @@ def test_eval_regression_until_start():
 
     phi = (mtl.parse("(X TRUE W X TRUE)"))
     phi(x, 0, quantitative=False)
+
+
+def test_eval_regression_timed_until():
+    """From issue #217"""
+    x = {
+        'start': [(0, True), (200, False)],
+        'success': [(0, False), (300, True)]
+    }
+    phi = mtl.parse('(~start U[0,120] success)')
+    assert phi(x, time=200, quantitative=False, dt=1)
+
+    y = {
+        'start': [(0, True), (1, False), (5, True), (6, True)],
+        'success': [(0, False), (20, True)]
+    }
+    phi1 = mtl.parse('(start U[0,20] success)')
+    assert phi1(y, time=6, quantitative=False, dt=1)
+
+    z = {
+        'start': [(0, True), (200, False)],
+        'success': [(0, False), (300, True)]
+    }
+    phi2 = mtl.parse('F[0,120]success')
+    assert phi2(z, time=181, quantitative=False, dt=1)

--- a/mtl/test_eval.py
+++ b/mtl/test_eval.py
@@ -20,3 +20,13 @@ def test_eval_regression_next_neg():
     v = f(d, quantitative=False, dt=1, time=None)
     assert not f(d, quantitative=False, dt=1)
     assert min(t for t, _ in v) >= 0
+
+
+def test_eval_regression_until_start():
+    """From issue #221"""
+    x = {
+        "ap1": [(0, True), (0.1, True), (0.2, False)],
+    }
+
+    phi = (mtl.parse("(X TRUE W X TRUE)"))
+    phi(x, 0, quantitative=False)


### PR DESCRIPTION
Fix #221 

Changes include:
- Add function to interpolate all tags in a signal at a given timestamp
- Force valuation of all tags on signal start
- Small regression test