### PR TITLE
Add support for fuzzy valuation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,10 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Vazquez-Chanlatte"
+  given-names: "Marcell"
+  orcid: "https://orcid.org/0000-0002-1248-0000"
+title: "py-metric-temporal-logic"
+version: 0
+date-released: 2021-08-02
+url: "https://github.com/mvcisback/py-metric-temporal-logic"

--- a/mtl/__init__.py
+++ b/mtl/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
 from mtl.ast import TOP, BOT
 from mtl.ast import (Interval, And, G, Neg,
-                     AtomicPred, WeakUntil, Next)
+                     AtomicPred, WeakUntil, Next, Implies)
 from mtl.parser import parse

--- a/mtl/ast.py
+++ b/mtl/ast.py
@@ -42,7 +42,7 @@ def _neg(exp):
     return Neg(exp)
 
 
-def _eval(exp, trace, time=False, *, dt=0.1, quantitative=True):
+def _eval(exp, trace, time=False, *, dt=0.1, quantitative=True, connectives=None):
     from mtl import evaluator
     return evaluator.pointwise_sat(exp, dt)(trace, time, quantitative)
 

--- a/mtl/ast.py
+++ b/mtl/ast.py
@@ -42,9 +42,9 @@ def _neg(exp):
     return Neg(exp)
 
 
-def _eval(exp, trace, time=False, *, dt=0.1, quantitative=True, connectives=None):
+def _eval(exp, trace, time=False, *, dt=0.1, quantitative=True, logic=None):
     from mtl import evaluator
-    return evaluator.pointwise_sat(exp, dt, connectives)(trace, time, quantitative)
+    return evaluator.pointwise_sat(exp, dt, logic)(trace, time, quantitative)
 
 
 def _timeshift(exp, t):
@@ -221,6 +221,7 @@ class WeakUntil:
     @property
     def children(self):
         return (self.arg1, self.arg2)
+
 
 @ast_class
 class Implies:

--- a/mtl/ast.py
+++ b/mtl/ast.py
@@ -126,7 +126,7 @@ def ast_class(cls):
     cls.atomic_predicates = property(_atomic_predicates)
     cls.evolve = attr.evolve
     cls.iff = sugar.iff
-    cls.implies = sugar.implies
+    cls.implies = lambda a, b: Implies(a, b)
     # Avoid circular dependence.
     cls.weak_until = lambda a, b: WeakUntil(a, b)
     cls.until = sugar.until
@@ -217,6 +217,18 @@ class WeakUntil:
 
     def __repr__(self):
         return f"({self.arg1} W {self.arg2})"
+
+    @property
+    def children(self):
+        return (self.arg1, self.arg2)
+
+@ast_class
+class Implies:
+    arg1: Node
+    arg2: Node
+
+    def __repr__(self):
+        return f"({self.arg1} → {self.arg2})"
 
     @property
     def children(self):

--- a/mtl/ast.py
+++ b/mtl/ast.py
@@ -29,7 +29,7 @@ def flatten_binary(phi, op, dropT, shortT):
 
 
 def _or(exp1, exp2):
-    return ~(~exp1 & ~exp2)
+    return flatten_binary(Or((exp1, exp2)), Or, BOT, TOP)
 
 
 def _and(exp1, exp2):
@@ -187,6 +187,10 @@ class NaryOpMTL:
 
 
 class And(NaryOpMTL):
+    OP = "&"
+
+
+class Or(NaryOpMTL):
     OP = "&"
 
 

--- a/mtl/ast.py
+++ b/mtl/ast.py
@@ -191,7 +191,7 @@ class And(NaryOpMTL):
 
 
 class Or(NaryOpMTL):
-    OP = "&"
+    OP = "|"
 
 
 @ast_class

--- a/mtl/ast.py
+++ b/mtl/ast.py
@@ -44,7 +44,7 @@ def _neg(exp):
 
 def _eval(exp, trace, time=False, *, dt=0.1, quantitative=True, connectives=None):
     from mtl import evaluator
-    return evaluator.pointwise_sat(exp, dt)(trace, time, quantitative)
+    return evaluator.pointwise_sat(exp, dt, connectives)(trace, time, quantitative)
 
 
 def _timeshift(exp, t):

--- a/mtl/connective.py
+++ b/mtl/connective.py
@@ -24,110 +24,55 @@ DEFAULT_FALSE = signal([(0, -1)], start=-OO, end=OO, tag=ast.BOT)
 DEFAULT_TRUE = signal([(0, 1)], start=-OO, end=OO, tag=ast.TOP)
 
 
-def _default_negation(v):
-    return -v
-
-
-def _default_implication(a, b):
-    return max(-a, b)
-
-
-default = _ConnectivesDef(_default_negation, min, max, _default_implication, DEFAULT_FALSE, DEFAULT_TRUE)
+default = _ConnectivesDef(
+    negation=lambda v: -v,
+    tnorm=min,
+    tconorm=max,
+    implication=lambda a, b: max(-a, b),
+    const_false=DEFAULT_FALSE,
+    const_true=DEFAULT_TRUE,
+)
 
 
 FUZZY_FALSE = signal([(0, 0.0)], start=-OO, end=OO, tag=ast.BOT)
 FUZZY_TRUE = signal([(0, 1.0)], start=-OO, end=OO, tag=ast.TOP)
 
-def _zadeh_negation(v):
-    return 1.0 - v
 
-
-def _zadeh_implication(a, b):
-    return max(1.0 - a, b)
-
-
-zadeh = _ConnectivesDef(_zadeh_negation, min, max, _zadeh_implication, FUZZY_FALSE, FUZZY_TRUE)
-
-
-def _godel_negation(v):
-    if v > 0.0:
-        return 0.0
-    else:
-        return 1.0
-
-
-def _godel_implication(a, b):
-    if a <= b:
-        return 1.0
-    else:
-        return b
+zadeh = _ConnectivesDef(
+    negation=lambda v: 1. - v,
+    tnorm=min,
+    tconorm=max,
+    implication=lambda a, b: max(1. - a, b),
+    const_false=FUZZY_FALSE,
+    const_true=FUZZY_TRUE,
+)
 
 
 godel = _ConnectivesDef(
-    negation=_godel_negation,
+    negation=lambda v: 0. if v > 0. else 1.,
     tnorm=min,
     tconorm=max,
-    implication=_godel_implication,
+    implication=lambda a, b: 1. if a <= b else b,
     const_false=FUZZY_FALSE,
     const_true=FUZZY_TRUE,
 )
-
-_lukasiewicz_negation = _zadeh_negation
-
-
-def _lukasiewicz_tnorm(v):
-    def _tnorm(a, b):
-        return max(a + b - 1.0, 0.0)
-
-    return reduce(_tnorm, v, initial=1.0)
-
-
-def _lukasiewicz_tconorm(v):
-    def _tconorm(a, b):
-        return min(a + b, 1.0)
-
-    return reduce(_tconorm, v, initial=0.0)
-
-
-def _lukasiewicz_implication(a, b):
-    return min(1 - a + b, 1.0)
 
 
 lukasiewicz = _ConnectivesDef(
-    negation=_lukasiewicz_negation,
-    tnorm=_lukasiewicz_tnorm,
-    tconorm=_lukasiewicz_tconorm,
-    implication=_lukasiewicz_implication,
+    negation=lambda v: 1. - v,
+    tnorm=lambda v: reduce(lambda a, b: max(a + b - 1., 0.), v, initial=1.),
+    tconorm=lambda v: reduce(lambda a, b: min(a + b, 1.), v, initial=0.),
+    implication=lambda a, b: min(1. - a + b, 1.),
     const_false=FUZZY_FALSE,
     const_true=FUZZY_TRUE,
 )
 
-_product_negation = _godel_negation
-
-
-def _product_tnorm(v):
-    return reduce(operator.mul, v, initial=1.0)
-
-
-def _product_tconorm(v):
-    def _tconorm(a, b):
-        return (a + b) - a * b
-
-    return reduce(_tconorm, v, initial=0.0)
-
-
-def _product_implication(a, b):
-    if a <= b:
-        return 1.0
-    else:
-        return b / a
-
 
 product = _ConnectivesDef(
-    negation=_product_negation,
-    tnorm=_product_tnorm,
-    tconorm=_product_tconorm,
-    implication=_product_implication,
+    negation=lambda v: 0. if v > 0. else 1.,
+    tnorm=lambda v: reduce(operator.mul, v, initial=1.),
+    tconorm=lambda v: reduce(lambda a, b: (a + b) - (a * b), v, initial=0.),
+    implication=lambda a, b: 1. if a <= b else b / a,
     const_false=FUZZY_FALSE,
     const_true=FUZZY_TRUE,
 )

--- a/mtl/connective.py
+++ b/mtl/connective.py
@@ -12,6 +12,7 @@ OO = float('inf')
 
 @attr.s(frozen=True, auto_attribs=True, repr=False, slots=True)
 class _ConnectivesDef:
+    name: str
     negation: Callable[[float], float]
     tnorm: Callable[[Iterable[float]], float]
     tconorm: Callable[[Iterable[float]], float]
@@ -19,12 +20,19 @@ class _ConnectivesDef:
     const_false: DiscreteSignal
     const_true: DiscreteSignal
 
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return "<ConnectivesDef {}>".format(self.name)
+
 
 DEFAULT_FALSE = signal([(0, -1)], start=-OO, end=OO, tag=ast.BOT)
 DEFAULT_TRUE = signal([(0, 1)], start=-OO, end=OO, tag=ast.TOP)
 
 
 default = _ConnectivesDef(
+    name="default",
     negation=lambda v: -v,
     tnorm=min,
     tconorm=max,
@@ -39,6 +47,7 @@ FUZZY_TRUE = signal([(0, 1.0)], start=-OO, end=OO, tag=ast.TOP)
 
 
 zadeh = _ConnectivesDef(
+    name="zadeh",
     negation=lambda v: 1. - v,
     tnorm=min,
     tconorm=max,
@@ -49,6 +58,7 @@ zadeh = _ConnectivesDef(
 
 
 godel = _ConnectivesDef(
+    name="godel",
     negation=lambda v: 0. if v > 0. else 1.,
     tnorm=min,
     tconorm=max,
@@ -59,6 +69,7 @@ godel = _ConnectivesDef(
 
 
 lukasiewicz = _ConnectivesDef(
+    name="lukasiewicz",
     negation=lambda v: 1. - v,
     tnorm=lambda v: reduce(lambda a, b: max(a + b - 1., 0.), v, initial=1.),
     tconorm=lambda v: reduce(lambda a, b: min(a + b, 1.), v, initial=0.),
@@ -69,6 +80,7 @@ lukasiewicz = _ConnectivesDef(
 
 
 product = _ConnectivesDef(
+    name="product",
     negation=lambda v: 0. if v > 0. else 1.,
     tnorm=lambda v: reduce(operator.mul, v, initial=1.),
     tconorm=lambda v: reduce(lambda a, b: (a + b) - (a * b), v, initial=0.),

--- a/mtl/connective.py
+++ b/mtl/connective.py
@@ -26,9 +26,11 @@ class _ConnectivesDef:
     def __repr__(self):
         return "<ConnectivesDef {}>".format(self.name)
 
+    @property
     def BOT(self):
         return signal([(0, self.const_false)], start=-OO, end=OO, tag=ast.BOT)
 
+    @property
     def TOP(self):
         return signal([(0, self.const_true)], start=-OO, end=OO, tag=ast.TOP)
 

--- a/mtl/connective.py
+++ b/mtl/connective.py
@@ -3,6 +3,11 @@ from functools import reduce
 from typing import Callable, Iterable
 
 import attr
+from discrete_signals import DiscreteSignal, signal
+
+from mtl import ast
+
+OO = float('inf')
 
 
 @attr.s(frozen=True, auto_attribs=True, repr=False, slots=True)
@@ -11,6 +16,12 @@ class _ConnectivesDef:
     tnorm: Callable[[Iterable[float]], float]
     tconorm: Callable[[Iterable[float]], float]
     implication: Callable[[float, float], float]
+    const_false: DiscreteSignal
+    const_true: DiscreteSignal
+
+
+DEFAULT_FALSE = signal([(0, -1)], start=-OO, end=OO, tag=ast.BOT)
+DEFAULT_TRUE = signal([(0, 1)], start=-OO, end=OO, tag=ast.TOP)
 
 
 def _default_negation(v):
@@ -21,18 +32,21 @@ def _default_implication(a, b):
     return max(-a, b)
 
 
-default = _ConnectivesDef(_default_negation, min, max, _default_implication)
+default = _ConnectivesDef(_default_negation, min, max, _default_implication, DEFAULT_FALSE, DEFAULT_TRUE)
 
+
+FUZZY_FALSE = signal([(0, 0.0)], start=-OO, end=OO, tag=ast.BOT)
+FUZZY_TRUE = signal([(0, 1.0)], start=-OO, end=OO, tag=ast.TOP)
 
 def _zadeh_negation(v):
     return 1.0 - v
 
 
 def _zadeh_implication(a, b):
-    return max(1.0 - 1, b)
+    return max(1.0 - a, b)
 
 
-zadeh = _ConnectivesDef(_zadeh_negation, min, max, _zadeh_implication)
+zadeh = _ConnectivesDef(_zadeh_negation, min, max, _zadeh_implication, FUZZY_FALSE, FUZZY_TRUE)
 
 
 def _godel_negation(v):
@@ -54,8 +68,9 @@ godel = _ConnectivesDef(
     tnorm=min,
     tconorm=max,
     implication=_godel_implication,
+    const_false=FUZZY_FALSE,
+    const_true=FUZZY_TRUE,
 )
-
 
 _lukasiewicz_negation = _zadeh_negation
 
@@ -63,12 +78,14 @@ _lukasiewicz_negation = _zadeh_negation
 def _lukasiewicz_tnorm(v):
     def _tnorm(a, b):
         return max(a + b - 1.0, 0.0)
+
     return reduce(_tnorm, v, initial=1.0)
 
 
 def _lukasiewicz_tconorm(v):
     def _tconorm(a, b):
         return min(a + b, 1.0)
+
     return reduce(_tconorm, v, initial=0.0)
 
 
@@ -81,8 +98,9 @@ lukasiewicz = _ConnectivesDef(
     tnorm=_lukasiewicz_tnorm,
     tconorm=_lukasiewicz_tconorm,
     implication=_lukasiewicz_implication,
+    const_false=FUZZY_FALSE,
+    const_true=FUZZY_TRUE,
 )
-
 
 _product_negation = _godel_negation
 
@@ -94,6 +112,7 @@ def _product_tnorm(v):
 def _product_tconorm(v):
     def _tconorm(a, b):
         return (a + b) - a * b
+
     return reduce(_tconorm, v, initial=0.0)
 
 
@@ -109,4 +128,6 @@ product = _ConnectivesDef(
     tnorm=_product_tnorm,
     tconorm=_product_tconorm,
     implication=_product_implication,
+    const_false=FUZZY_FALSE,
+    const_true=FUZZY_TRUE,
 )

--- a/mtl/connective.py
+++ b/mtl/connective.py
@@ -3,7 +3,7 @@ from functools import reduce
 from typing import Callable, Iterable
 
 import attr
-from discrete_signals import DiscreteSignal, signal
+from discrete_signals import signal
 
 from mtl import ast
 
@@ -35,8 +35,8 @@ class _ConnectivesDef:
         return signal([(0, self.const_true)], start=-OO, end=OO, tag=ast.TOP)
 
 
-DEFAULT_FALSE = -1.0
-DEFAULT_TRUE = 1.0
+DEFAULT_FALSE = -OO
+DEFAULT_TRUE = OO
 
 
 default = _ConnectivesDef(

--- a/mtl/connective.py
+++ b/mtl/connective.py
@@ -71,8 +71,8 @@ godel = _ConnectivesDef(
 lukasiewicz = _ConnectivesDef(
     name="lukasiewicz",
     negation=lambda v: 1. - v,
-    tnorm=lambda v: reduce(lambda a, b: max(a + b - 1., 0.), v, initial=1.),
-    tconorm=lambda v: reduce(lambda a, b: min(a + b, 1.), v, initial=0.),
+    tnorm=lambda v: reduce(lambda a, b: max(a + b - 1., 0.), v, 1.),
+    tconorm=lambda v: reduce(lambda a, b: min(a + b, 1.), v, 0.),
     implication=lambda a, b: min(1. - a + b, 1.),
     const_false=FUZZY_FALSE,
     const_true=FUZZY_TRUE,
@@ -82,8 +82,8 @@ lukasiewicz = _ConnectivesDef(
 product = _ConnectivesDef(
     name="product",
     negation=lambda v: 0. if v > 0. else 1.,
-    tnorm=lambda v: reduce(operator.mul, v, initial=1.),
-    tconorm=lambda v: reduce(lambda a, b: (a + b) - (a * b), v, initial=0.),
+    tnorm=lambda v: reduce(operator.mul, v, 1.),
+    tconorm=lambda v: reduce(lambda a, b: (a + b) - (a * b), v, 0.),
     implication=lambda a, b: 1. if a <= b else b / a,
     const_false=FUZZY_FALSE,
     const_true=FUZZY_TRUE,

--- a/mtl/connective.py
+++ b/mtl/connective.py
@@ -1,0 +1,112 @@
+import operator
+from functools import reduce
+from typing import Callable, Iterable
+
+import attr
+
+
+@attr.s(frozen=True, auto_attribs=True, repr=False, slots=True)
+class _ConnectivesDef:
+    negation: Callable[[float], float]
+    tnorm: Callable[[Iterable[float]], float]
+    tconorm: Callable[[Iterable[float]], float]
+    implication: Callable[[float, float], float]
+
+
+def _default_negation(v):
+    return -v
+
+
+def _default_implication(a, b):
+    return max(-a, b)
+
+
+default = _ConnectivesDef(_default_negation, min, max, _default_implication)
+
+
+def _zadeh_negation(v):
+    return 1.0 - v
+
+
+def _zadeh_implication(a, b):
+    return max(1.0 - 1, b)
+
+
+zadeh = _ConnectivesDef(_zadeh_negation, min, max, _zadeh_implication)
+
+
+def _godel_negation(v):
+    if v > 0.0:
+        return 0.0
+    else:
+        return 1.0
+
+
+def _godel_implication(a, b):
+    if a <= b:
+        return 1.0
+    else:
+        return b
+
+
+godel = _ConnectivesDef(
+    negation=_godel_negation,
+    tnorm=min,
+    tconorm=max,
+    implication=_godel_implication,
+)
+
+
+_lukasiewicz_negation = _zadeh_negation
+
+
+def _lukasiewicz_tnorm(v):
+    def _tnorm(a, b):
+        return max(a + b - 1.0, 0.0)
+    return reduce(_tnorm, v, initial=1.0)
+
+
+def _lukasiewicz_tconorm(v):
+    def _tconorm(a, b):
+        return min(a + b, 1.0)
+    return reduce(_tconorm, v, initial=0.0)
+
+
+def _lukasiewicz_implication(a, b):
+    return min(1 - a + b, 1.0)
+
+
+lukasiewicz = _ConnectivesDef(
+    negation=_lukasiewicz_negation,
+    tnorm=_lukasiewicz_tnorm,
+    tconorm=_lukasiewicz_tconorm,
+    implication=_lukasiewicz_implication,
+)
+
+
+_product_negation = _godel_negation
+
+
+def _product_tnorm(v):
+    return reduce(operator.mul, v, initial=1.0)
+
+
+def _product_tconorm(v):
+    def _tconorm(a, b):
+        return (a + b) - a * b
+    return reduce(_tconorm, v, initial=0.0)
+
+
+def _product_implication(a, b):
+    if a <= b:
+        return 1.0
+    else:
+        return b / a
+
+
+product = _ConnectivesDef(
+    negation=_product_negation,
+    tnorm=_product_tnorm,
+    tconorm=_product_tconorm,
+    implication=_product_implication,
+)

--- a/mtl/connective.py
+++ b/mtl/connective.py
@@ -17,8 +17,8 @@ class _ConnectivesDef:
     tnorm: Callable[[Iterable[float]], float]
     tconorm: Callable[[Iterable[float]], float]
     implication: Callable[[float, float], float]
-    const_false: DiscreteSignal
-    const_true: DiscreteSignal
+    const_false: float
+    const_true: float
 
     def __str__(self):
         return self.name
@@ -26,9 +26,15 @@ class _ConnectivesDef:
     def __repr__(self):
         return "<ConnectivesDef {}>".format(self.name)
 
+    def BOT(self):
+        return signal([(0, self.const_false)], start=-OO, end=OO, tag=ast.BOT)
 
-DEFAULT_FALSE = signal([(0, -1)], start=-OO, end=OO, tag=ast.BOT)
-DEFAULT_TRUE = signal([(0, 1)], start=-OO, end=OO, tag=ast.TOP)
+    def TOP(self):
+        return signal([(0, self.const_true)], start=-OO, end=OO, tag=ast.TOP)
+
+
+DEFAULT_FALSE = -1.0
+DEFAULT_TRUE = 1.0
 
 
 default = _ConnectivesDef(
@@ -42,8 +48,8 @@ default = _ConnectivesDef(
 )
 
 
-FUZZY_FALSE = signal([(0, 0.0)], start=-OO, end=OO, tag=ast.BOT)
-FUZZY_TRUE = signal([(0, 1.0)], start=-OO, end=OO, tag=ast.TOP)
+FUZZY_FALSE = 0.0
+FUZZY_TRUE = 1.0
 
 
 zadeh = _ConnectivesDef(

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -57,8 +57,8 @@ def booleanize_signal(sig):
     ))
 
 
-def pointwise_sat(phi, dt=0.1):
-    f = eval_mtl(phi, dt)
+def pointwise_sat(phi, dt=0.1, connectives=None):
+    f = eval_mtl(phi, dt, connectives)
 
     def _eval_mtl(x, t=0, quantitative=False):
         sig = to_signal(x)
@@ -81,13 +81,13 @@ def pointwise_sat(phi, dt=0.1):
 
 
 @singledispatch
-def eval_mtl(phi, dt):
+def eval_mtl(phi, dt, connectives):
     raise NotImplementedError
 
 
 @eval_mtl.register(ast.And)
-def eval_mtl_and(phi, dt):
-    fs = [eval_mtl(arg, dt) for arg in phi.args]
+def eval_mtl_and(phi, dt, connectives):
+    fs = [eval_mtl(arg, dt, connectives) for arg in phi.args]
 
     def _eval(x):
         sigs = [f(x) for f in fs]
@@ -109,8 +109,8 @@ def apply_weak_until(left_key, right_key, sig):
 
 
 @eval_mtl.register(ast.WeakUntil)
-def eval_mtl_until(phi, dt):
-    f1, f2 = eval_mtl(phi.arg1, dt), eval_mtl(phi.arg2, dt)
+def eval_mtl_until(phi, dt, connectives):
+    f1, f2 = eval_mtl(phi.arg1, dt, connectives), eval_mtl(phi.arg2, dt, connectives)
 
     def _eval(x):
         sig = dense_compose(f1(x), f2(x), init=-OO)
@@ -128,8 +128,8 @@ def apply_implies(left_key, right_key, sig):
 
 
 @eval_mtl.register(ast.Implies)
-def eval_mtl_implies(phi, dt):
-    f1, f2 = eval_mtl(phi.arg1, dt), eval_mtl(phi.arg2, dt)
+def eval_mtl_implies(phi, dt, connectives):
+    f1, f2 = eval_mtl(phi.arg1, dt, connectives), eval_mtl(phi.arg2, dt, connectives)
 
     def _eval(x):
         sig = dense_compose(f1(x), f2(x), init=-OO)
@@ -140,8 +140,8 @@ def eval_mtl_implies(phi, dt):
 
 
 @eval_mtl.register(ast.G)
-def eval_mtl_g(phi, dt):
-    f = eval_mtl(phi.arg, dt)
+def eval_mtl_g(phi, dt, connectives):
+    f = eval_mtl(phi.arg, dt, connectives)
     a, b = phi.interval
     if b < a:
         return lambda x: CONST_TRUE.retag({ast.TOP: phi})
@@ -167,8 +167,8 @@ def eval_mtl_g(phi, dt):
 
 
 @eval_mtl.register(ast.Neg)
-def eval_mtl_neg(phi, dt):
-    f = eval_mtl(phi.arg, dt)
+def eval_mtl_neg(phi, dt, connectives):
+    f = eval_mtl(phi.arg, dt, connectives)
 
     def _eval(x):
         return f(x).map(lambda v: -v[phi.arg], tag=phi)
@@ -177,8 +177,8 @@ def eval_mtl_neg(phi, dt):
 
 
 @eval_mtl.register(ast.Next)
-def eval_mtl_next(phi, dt):
-    f = eval_mtl(phi.arg, dt)
+def eval_mtl_next(phi, dt, connectives):
+    f = eval_mtl(phi.arg, dt, connectives)
 
     def _eval(x):
         return (f(x) << dt).retag({phi.arg: phi})
@@ -187,7 +187,7 @@ def eval_mtl_next(phi, dt):
 
 
 @eval_mtl.register(ast.AtomicPred)
-def eval_mtl_ap(phi, _):
+def eval_mtl_ap(phi, _, _2):
     def _eval(x):
         return x.project({phi.id}).retag({phi.id: phi})
 
@@ -195,5 +195,5 @@ def eval_mtl_ap(phi, _):
 
 
 @eval_mtl.register(type(ast.BOT))
-def eval_mtl_bot(_, _1):
+def eval_mtl_bot(_, _1, _2):
     return lambda x: CONST_FALSE

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -111,7 +111,8 @@ def eval_mtl_or(phi, dt, logic):
 
 
 def apply_weak_until(left_key, right_key, sig, logic):
-    ut, ga = -OO, OO
+    ut = logic.const_false
+    ga = logic.const_true
 
     for t in reversed(sig.times()):
         left, right = interp(sig, t, left_key), interp(sig, t, right_key)

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -121,6 +121,24 @@ def eval_mtl_until(phi, dt):
     return _eval
 
 
+def apply_implies(left_key, right_key, sig):
+    for t in sig.times():
+        left, right = interp(sig, t, left_key), interp(sig, t, right_key)
+        yield (t, max(-left, right))
+
+
+@eval_mtl.register(ast.Implies)
+def eval_mtl_implies(phi, dt):
+    f1, f2 = eval_mtl(phi.arg1, dt), eval_mtl(phi.arg2, dt)
+
+    def _eval(x):
+        sig = dense_compose(f1(x), f2(x), init=-OO)
+        data = apply_implies(phi.arg1, phi.arg2, sig)
+        return signal(data, x.start, OO, tag=phi)
+
+    return _eval
+
+
 @eval_mtl.register(ast.G)
 def eval_mtl_g(phi, dt):
     f = eval_mtl(phi.arg, dt)

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -23,6 +23,7 @@ def to_signal(ts_mapping) -> DiscreteSignal:
 
 
 def interp(sig, t, tag=None):
+<<<<<<< HEAD
     if t in sig.data and tag in sig.data[t]:
         return sig.data[t][tag]
     s = sig[:t]
@@ -30,6 +31,16 @@ def interp(sig, t, tag=None):
         if tag in s.data[i]:
             return s.data[i][tag]
     return None
+=======
+    idx = max(sig.data.bisect_right(t) - 1, 0)
+    keys = sig.data.keys()
+    while idx > 0:
+        if tag in sig[keys[idx]]:
+            return sig[keys[idx]][tag]
+        idx = idx - 1
+    key = keys[0]
+    return sig[key][tag]
+>>>>>>> 2bf91f8 (Prevent signal duplication during value interpolation)
 
 
 def interp_all(sig, t, end=OO):

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -129,11 +129,7 @@ def eval_mtl_until(phi, dt, logic):
         sig = dense_compose(f1(x), f2(x), init=-OO)
         sig = sig | interp_all(sig, x.start, OO)  # Force valuation at start
         data = apply_weak_until(phi.arg1, phi.arg2, sig, logic)
-        # FIXME signal removes entries outside [start:end] w/o interpolation
-        d = list(data)
-        s = signal(d, min(u for (u, _) in d), OO, tag=phi)
-        d.append((x.start, interp(s, x.start, phi)))
-        return signal(d, x.start, OO, tag=phi)
+        return signal(data, x.start, OO, tag=phi)
 
     return _eval
 
@@ -150,12 +146,9 @@ def eval_mtl_implies(phi, dt, logic):
 
     def _eval(x):
         sig = dense_compose(f1(x), f2(x), init=-OO)
+        sig = sig | interp_all(sig, x.start, OO)  # Force valuation at start
         data = apply_implies(phi.arg1, phi.arg2, sig, logic)
-        # FIXME signal removes entries outside [start:end] w/o interpolation
-        d = list(data)
-        s = signal(d, min(u for (u, _) in d), OO, tag=phi)
-        d.append((x.start, interp(s, x.start, phi)))
-        return signal(d, x.start, OO, tag=phi)
+        return signal(data, x.start, OO, tag=phi)
 
     return _eval
 

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -10,9 +10,8 @@ from discrete_signals import signal, DiscreteSignal
 
 from mtl import ast
 
+
 OO = float('inf')
-CONST_FALSE = signal([(0, -1)], start=-OO, end=OO, tag=ast.BOT)
-CONST_TRUE = signal([(0, 1)], start=-OO, end=OO, tag=ast.TOP)
 
 
 def to_signal(ts_mapping) -> DiscreteSignal:
@@ -151,7 +150,7 @@ def eval_mtl_g(phi, dt, connectives):
     f = eval_mtl(phi.arg, dt, connectives)
     a, b = phi.interval
     if b < a:
-        return lambda x: CONST_TRUE.retag({ast.TOP: phi})
+        return lambda x: connectives.const_true.retag({ast.TOP: phi})
 
     def _min(val):
         return connectives.tnorm(val[phi.arg])
@@ -202,5 +201,5 @@ def eval_mtl_ap(phi, _, _2):
 
 
 @eval_mtl.register(type(ast.BOT))
-def eval_mtl_bot(_, _1, _2):
-    return lambda x: CONST_FALSE
+def eval_mtl_bot(_, _1, connectives):
+    return lambda x: connectives.const_false

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -158,7 +158,7 @@ def eval_mtl_g(phi, dt, logic):
     f = eval_mtl(phi.arg, dt, logic)
     a, b = phi.interval
     if b < a:
-        return lambda x: logic.const_true.retag({ast.TOP: phi})
+        return lambda x: logic.TOP.retag({ast.TOP: phi})
 
     def _min(val):
         return logic.tnorm(val[phi.arg])
@@ -210,4 +210,4 @@ def eval_mtl_ap(phi, _, _2):
 
 @eval_mtl.register(type(ast.BOT))
 def eval_mtl_bot(_, _1, logic):
-    return lambda x: logic.const_false
+    return lambda x: logic.BOT

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -92,7 +92,7 @@ def eval_mtl_and(phi, dt, logic):
 
     def _eval(x):
         sigs = [f(x) for f in fs]
-        sig = reduce(lambda x, y: dense_compose(x, y, init=OO), sigs)
+        sig = reduce(lambda x, y: dense_compose(x, y, init=logic.const_true), sigs)
         return sig.map(lambda v: logic.tnorm(v.values()), tag=phi)
 
     return _eval
@@ -104,7 +104,7 @@ def eval_mtl_or(phi, dt, logic):
 
     def _eval(x):
         sigs = [f(x) for f in fs]
-        sig = reduce(lambda x, y: dense_compose(x, y, init=OO), sigs)
+        sig = reduce(lambda x, y: dense_compose(x, y, init=logic.const_true), sigs)
         return sig.map(lambda v: logic.tconorm(v.values()), tag=phi)
 
     return _eval
@@ -127,10 +127,10 @@ def eval_mtl_until(phi, dt, logic):
     f1, f2 = eval_mtl(phi.arg1, dt, logic), eval_mtl(phi.arg2, dt, logic)
 
     def _eval(x):
-        sig = dense_compose(f1(x), f2(x), init=-OO)
-        sig = sig | interp_all(sig, x.start, OO)  # Force valuation at start
+        sig = dense_compose(f1(x), f2(x), init=logic.const_false)
+        sig = sig | interp_all(sig, x.start, logic.const_true)  # Force valuation at start
         data = apply_weak_until(phi.arg1, phi.arg2, sig, logic)
-        return signal(data, x.start, OO, tag=phi)
+        return signal(data, x.start, logic.const_true, tag=phi)
 
     return _eval
 
@@ -146,10 +146,10 @@ def eval_mtl_implies(phi, dt, logic):
     f1, f2 = eval_mtl(phi.arg1, dt, logic), eval_mtl(phi.arg2, dt, logic)
 
     def _eval(x):
-        sig = dense_compose(f1(x), f2(x), init=-OO)
-        sig = sig | interp_all(sig, x.start, OO)  # Force valuation at start
+        sig = dense_compose(f1(x), f2(x), init=logic.const_false)
+        sig = sig | interp_all(sig, x.start, logic.const_true)  # Force valuation at start
         data = apply_implies(phi.arg1, phi.arg2, sig, logic)
-        return signal(data, x.start, OO, tag=phi)
+        return signal(data, x.start, logic.const_true, tag=phi)
 
     return _eval
 

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -116,9 +116,9 @@ def apply_weak_until(left_key, right_key, sig, logic):
     for t in reversed(sig.times()):
         left, right = interp(sig, t, left_key), interp(sig, t, right_key)
 
-        ga = logic.tnorm(ga, left)
-        ut = max(right, logic.tnorm(left, ut))
-        yield (t, logic.tconorm(ut, ga))
+        ga = logic.tnorm([ga, left])
+        ut = max(right, logic.tnorm([left, ut]))
+        yield (t, logic.tconorm([ut, ga]))
 
 
 @eval_mtl.register(ast.WeakUntil)

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -1,6 +1,5 @@
 # TODO: figure out how to deduplicate this with robustness
 # - Abstract as working on distributive lattice
-
 import operator as op
 from collections import defaultdict
 from functools import reduce, singledispatch
@@ -118,7 +117,11 @@ def eval_mtl_until(phi, dt, logic):
         sig = dense_compose(f1(x), f2(x), init=-OO)
         sig = sig | interp_all(sig, x.start, OO)  # Force valuation at start
         data = apply_weak_until(phi.arg1, phi.arg2, sig, logic)
-        return signal(data, x.start, OO, tag=phi)
+        # FIXME signal removes entries outside [start:end] w/o interpolation
+        d = list(data)
+        s = signal(d, min(u for (u, _) in d), OO, tag=phi)
+        d.append((x.start, interp(s, x.start, phi)))
+        return signal(d, x.start, OO, tag=phi)
 
     return _eval
 
@@ -136,7 +139,11 @@ def eval_mtl_implies(phi, dt, logic):
     def _eval(x):
         sig = dense_compose(f1(x), f2(x), init=-OO)
         data = apply_implies(phi.arg1, phi.arg2, sig, logic)
-        return signal(data, x.start, OO, tag=phi)
+        # FIXME signal removes entries outside [start:end] w/o interpolation
+        d = list(data)
+        s = signal(d, min(u for (u, _) in d), OO, tag=phi)
+        d.append((x.start, interp(s, x.start, phi)))
+        return signal(d, x.start, OO, tag=phi)
 
     return _eval
 

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -97,7 +97,8 @@ def eval_mtl_and(phi, dt, logic):
 
     def _eval(x):
         sigs = [f(x) for f in fs]
-        sig = reduce(lambda x, y: dense_compose(x, y, init=logic.const_true), sigs)
+        sig = reduce(lambda x, y:
+        			 dense_compose(x, y, init=logic.const_true), sigs)
         return sig.map(lambda v: logic.tnorm(v.values()), tag=phi)
 
     return _eval
@@ -109,7 +110,8 @@ def eval_mtl_or(phi, dt, logic):
 
     def _eval(x):
         sigs = [f(x) for f in fs]
-        sig = reduce(lambda x, y: dense_compose(x, y, init=logic.const_true), sigs)
+        sig = reduce(lambda x, y:
+        			 dense_compose(x, y, init=logic.const_true), sigs)
         return sig.map(lambda v: logic.tconorm(v.values()), tag=phi)
 
     return _eval
@@ -135,7 +137,7 @@ def eval_mtl_until(phi, dt, logic):
         sig = dense_compose(f1(x), f2(x), init=logic.const_false)
         sig = sig | interp_all(sig, x.start, logic.const_true)  # Force valuation at start
         data = apply_weak_until(phi.arg1, phi.arg2, sig, logic)
-        return signal(data, x.start, logic.const_true, tag=phi)
+        return signal(data, x.start, x.end, tag=phi)
 
     return _eval
 
@@ -154,7 +156,7 @@ def eval_mtl_implies(phi, dt, logic):
         sig = dense_compose(f1(x), f2(x), init=logic.const_false)
         sig = sig | interp_all(sig, x.start, logic.const_true)  # Force valuation at start
         data = apply_implies(phi.arg1, phi.arg2, sig, logic)
-        return signal(data, x.start, logic.const_true, tag=phi)
+        return signal(data, x.start, x.end, tag=phi)
 
     return _eval
 

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -83,7 +83,7 @@ def pointwise_sat(phi, dt=0.1, logic=None):
 
 @singledispatch
 def eval_mtl(phi, dt, logic):
-    raise NotImplementedError
+    return lambda _: signal([(0, phi)], start=-OO, end=OO, tag=phi)
 
 
 @eval_mtl.register(ast.And)

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -95,20 +95,20 @@ def eval_mtl_and(phi, dt, connectives):
     def _eval(x):
         sigs = [f(x) for f in fs]
         sig = reduce(lambda x, y: dense_compose(x, y, init=OO), sigs)
-        return sig.map(lambda v: min(v.values()), tag=phi)
+        return sig.map(lambda v: connectives.tnorm(v.values()), tag=phi)
 
     return _eval
 
 
-def apply_weak_until(left_key, right_key, sig):
-    prev, max_right = OO, -OO
+def apply_weak_until(left_key, right_key, sig, connectives):
+    ut, ga = -OO, OO
 
     for t in reversed(sig.times()):
         left, right = interp(sig, t, left_key), interp(sig, t, right_key)
 
-        max_right = max(max_right, right)
-        prev = max(right, min(left, prev), -max_right)
-        yield (t, prev)
+        ga = connectives.tnorm(ga, left)
+        ut = max(right, connectives.tnorm(left, ut))
+        yield (t, connectives.tconorm(ut, ga))
 
 
 @eval_mtl.register(ast.WeakUntil)
@@ -117,17 +117,21 @@ def eval_mtl_until(phi, dt, connectives):
 
     def _eval(x):
         sig = dense_compose(f1(x), f2(x), init=-OO)
+<<<<<<< HEAD
         sig = sig | interp_all(sig, x.start, OO)  # Force valuation at start
         data = apply_weak_until(phi.arg1, phi.arg2, sig)
+=======
+        data = apply_weak_until(phi.arg1, phi.arg2, sig, connectives)
+>>>>>>> 9d1fef8 (Implement ast evaluation using connective operations)
         return signal(data, x.start, OO, tag=phi)
 
     return _eval
 
 
-def apply_implies(left_key, right_key, sig):
+def apply_implies(left_key, right_key, sig, connectives):
     for t in sig.times():
         left, right = interp(sig, t, left_key), interp(sig, t, right_key)
-        yield (t, max(-left, right))
+        yield (t, connectives.implication(left, right))
 
 
 @eval_mtl.register(ast.Implies)
@@ -136,7 +140,7 @@ def eval_mtl_implies(phi, dt, connectives):
 
     def _eval(x):
         sig = dense_compose(f1(x), f2(x), init=-OO)
-        data = apply_implies(phi.arg1, phi.arg2, sig)
+        data = apply_implies(phi.arg1, phi.arg2, sig, connectives)
         return signal(data, x.start, OO, tag=phi)
 
     return _eval
@@ -150,7 +154,7 @@ def eval_mtl_g(phi, dt, connectives):
         return lambda x: CONST_TRUE.retag({ast.TOP: phi})
 
     def _min(val):
-        return min(val[phi.arg])
+        return connectives.tnorm(val[phi.arg])
 
     def _eval(x):
         tmp = f(x)
@@ -174,7 +178,7 @@ def eval_mtl_neg(phi, dt, connectives):
     f = eval_mtl(phi.arg, dt, connectives)
 
     def _eval(x):
-        return f(x).map(lambda v: -v[phi.arg], tag=phi)
+        return f(x).map(lambda v: connectives.negation(v[phi.arg]), tag=phi)
 
     return _eval
 

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -23,11 +23,13 @@ def to_signal(ts_mapping) -> DiscreteSignal:
 
 
 def interp(sig, t, tag=None):
-    # TODO: return function that interpolates the whole signal.
-    sig = sig.project({tag})
-    idx = max(sig.data.bisect_right(t) - 1, 0)
-    key = sig.data.keys()[idx]
-    return sig[key][tag]
+    if t in sig.data and tag in sig.data[t]:
+        return sig.data[t][tag]
+    s = sig[:t]
+    for i in reversed(s.data):
+        if tag in s.data[i]:
+            return s.data[i][tag]
+    return None
 
 
 def interp_all(sig, t, end=OO):

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -29,7 +29,8 @@ def interp(sig, t, tag=None):
     for i in reversed(s.data):
         if tag in s.data[i]:
             return s.data[i][tag]
-    return None
+    key = sig.data.keys()[0]
+    return sig[key][tag]
 
 
 def interp_all(sig, t, end=OO):

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -58,6 +58,9 @@ def booleanize_signal(sig):
 
 
 def pointwise_sat(phi, dt=0.1, connectives=None):
+    if connectives is None:
+        from mtl import connective
+        connectives = connective.default
     f = eval_mtl(phi, dt, connectives)
 
     def _eval_mtl(x, t=0, quantitative=False):

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -68,8 +68,7 @@ def pointwise_sat(phi, dt=0.1, logic=None):
 
     def _eval_mtl(x, t=0, quantitative=False):
         sig = to_signal(x)
-        if not quantitative:
-            sig = booleanize_signal(sig, logic)
+        sig = booleanize_signal(sig, logic)
 
         start_time = sig.items()[0][0]
 

--- a/mtl/evaluator.py
+++ b/mtl/evaluator.py
@@ -98,6 +98,18 @@ def eval_mtl_and(phi, dt, logic):
     return _eval
 
 
+@eval_mtl.register(ast.Or)
+def eval_mtl_or(phi, dt, logic):
+    fs = [eval_mtl(arg, dt, logic) for arg in phi.args]
+
+    def _eval(x):
+        sigs = [f(x) for f in fs]
+        sig = reduce(lambda x, y: dense_compose(x, y, init=OO), sigs)
+        return sig.map(lambda v: logic.tconorm(v.values()), tag=phi)
+
+    return _eval
+
+
 def apply_weak_until(left_key, right_key, sig, logic):
     ut, ga = -OO, OO
 

--- a/mtl/sugar.py
+++ b/mtl/sugar.py
@@ -10,7 +10,7 @@ def env(phi, *, lo=0, hi=float('inf')):
 
 
 def implies(x, y):
-    return ~x | y
+    return ast.Implies(x, y)
 
 
 def xor(x, y):

--- a/mtl/test_ast.py
+++ b/mtl/test_ast.py
@@ -28,4 +28,4 @@ def test_identities(phi):
 def test_walk():
     phi = mtl.parse(
         '(([ ][0, 1] ap1 & < >[1,2] ap2) | (@ap1 U ap2))')
-    assert len(list((~phi).walk())) == 19
+    assert len(list((~phi).walk())) == 18

--- a/mtl/test_fuzzy.py
+++ b/mtl/test_fuzzy.py
@@ -1,6 +1,5 @@
 from hypothesis import given, strategies as st
 
-import math
 import mtl
 
 from mtl.connective import godel, zadeh, lukasiewicz, product
@@ -103,7 +102,8 @@ def test_fuzzy_eval(con, phi1, phi2, phi3):
     assert (not v2 >= v3) or con.tconorm([v1, v2]) >= con.tconorm([v1, v3])
     assert con.tnorm([v1, v2]) <= v1
     assert con.tconorm([v1, v2]) >= v1
-    assert (not v1 <= v2) or (con.implication(v1, v3) >= con.implication(v2, v3))
-    assert (not v2 <= v3) or (con.implication(v1, v2) <= con.implication(v1, v3))
+    assert (not v1 <= v2) \
+        or (con.implication(v1, v3) >= con.implication(v2, v3))
+    assert (not v2 <= v3) \
+        or (con.implication(v1, v2) <= con.implication(v1, v3))
     assert con.implication(v1, v2) >= max(con.negation(v1), v2)
-

--- a/mtl/test_fuzzy.py
+++ b/mtl/test_fuzzy.py
@@ -1,8 +1,20 @@
 from hypothesis import given, strategies as st
 
+import math
 import mtl
 
 from mtl.connective import godel, zadeh, lukasiewicz, product
+from mtl.hypothesis import MetricTemporalLogicStrategy
+
+
+VALUES = {
+    "ap1": [(0, 1.), (0.1, 1.), (0.2, 0.)],
+    "ap2": [(0, 0.), (0.2, 1.), (0.5, 0.)],
+    "ap3": [(0, 1.), (0.1, 1.), (0.3, 0.)],
+    "ap4": [(0, 0.), (0.1, 0.), (0.3, 0.)],
+    "ap5": [(0, 0.), (0.1, 0.), (0.3, 1.)],
+    "ap6": [(0, 1.), (float('inf'), 1.)],
+}
 
 
 def prepare_values(a, b, c):
@@ -72,3 +84,26 @@ def test_fuzzy_always(con, a: float, b: float, c: float):
 def test_fuzzy_neg(con, a: float, b: float, c: float):
     x = prepare_values(a, b, c)
     assert mtl.parse("~ap1")(x, 0, logic=con) == con.negation(a)
+
+
+@given(
+    st.sampled_from([zadeh, godel, lukasiewicz, product]),
+    MetricTemporalLogicStrategy,
+    MetricTemporalLogicStrategy,
+    MetricTemporalLogicStrategy
+)
+def test_fuzzy_eval(con, phi1, phi2, phi3):
+    v1 = phi1(VALUES, 0, logic=con)
+    v2 = phi2(VALUES, 0, logic=con)
+    v3 = phi3(VALUES, 0, logic=con)
+    nv1 = (~phi1)(VALUES, 0, logic=con)
+    nv2 = (~phi2)(VALUES, 0, logic=con)
+    assert (not v1 <= v2) or (nv1 >= nv2)
+    assert (not v2 >= v3) or con.tnorm([v1, v2]) >= con.tnorm([v1, v3])
+    assert (not v2 >= v3) or con.tconorm([v1, v2]) >= con.tconorm([v1, v3])
+    assert con.tnorm([v1, v2]) <= v1
+    assert con.tconorm([v1, v2]) >= v1
+    assert (not v1 <= v2) or (con.implication(v1, v3) >= con.implication(v2, v3))
+    assert (not v2 <= v3) or (con.implication(v1, v2) <= con.implication(v1, v3))
+    assert con.implication(v1, v2) >= max(con.negation(v1), v2)
+

--- a/mtl/test_fuzzy.py
+++ b/mtl/test_fuzzy.py
@@ -1,0 +1,74 @@
+from hypothesis import given, strategies as st
+
+import mtl
+
+from mtl.connective import godel, zadeh, lukasiewicz, product
+
+
+def prepare_values(a, b, c):
+    return {
+        "ap1": [(0., a), (0.1, b), (0.2, c)],
+        "apa": [(0., a), ],
+        "apb": [(0., b), ],
+        "apc": [(0., c), ],
+    }
+
+
+@given(
+    st.sampled_from([zadeh, godel, lukasiewicz, product]),
+    st.floats(min_value=0., max_value=1., width=16),
+    st.floats(min_value=0., max_value=1., width=16),
+    st.floats(min_value=0., max_value=1., width=16),
+)
+def test_fuzzy_binop(con, a: float, b: float, c: float):
+    x = prepare_values(a, b, c)
+    assert mtl.parse("(apa & apb)")(x, 0, logic=con) == con.tnorm([a, b])
+    assert mtl.parse("(apa & apb & apc)")(x, 0, logic=con) \
+        == con.tnorm([a, b, c])
+
+    assert mtl.parse("(apa | apb)")(x, 0, logic=con) == con.tconorm([a, b])
+    assert mtl.parse("(apa | apb | apc)")(x, 0, logic=con) \
+        == con.tconorm([a, b, c])
+
+
+@given(
+    st.sampled_from([zadeh, godel, lukasiewicz, product]),
+    st.floats(min_value=0., max_value=1., width=16),
+    st.floats(min_value=0., max_value=1., width=16),
+    st.floats(min_value=0., max_value=1., width=16),
+)
+def test_fuzzy_until(con, a: float, b: float, c: float):
+    pass
+
+
+@given(
+    st.sampled_from([zadeh, godel, lukasiewicz, product]),
+    st.floats(min_value=0., max_value=1., width=16),
+    st.floats(min_value=0., max_value=1., width=16),
+    st.floats(min_value=0., max_value=1., width=16),
+)
+def test_fuzzy_implies(con, a: float, b: float, c: float):
+    x = prepare_values(a, b, c)
+    assert mtl.parse("(apa -> apb)")(x, 0, logic=con) == con.implication(a, b)
+
+
+@given(
+    st.sampled_from([zadeh, godel, lukasiewicz, product]),
+    st.floats(min_value=0., max_value=1., width=16),
+    st.floats(min_value=0., max_value=1., width=16),
+    st.floats(min_value=0., max_value=1., width=16),
+)
+def test_fuzzy_always(con, a: float, b: float, c: float):
+    x = prepare_values(a, b, c)
+    assert mtl.parse("G ap1")(x, 0, logic=con) == con.tnorm([a, b, c])
+
+
+@given(
+    st.sampled_from([zadeh, godel, lukasiewicz, product]),
+    st.floats(min_value=0., max_value=1., width=16),
+    st.floats(min_value=0., max_value=1., width=16),
+    st.floats(min_value=0., max_value=1., width=16),
+)
+def test_fuzzy_neg(con, a: float, b: float, c: float):
+    x = prepare_values(a, b, c)
+    assert mtl.parse("~ap1")(x, 0, logic=con) == con.negation(a)

--- a/mtl/test_fuzzy_connective.py
+++ b/mtl/test_fuzzy_connective.py
@@ -1,0 +1,58 @@
+import hypothesis.strategies as st
+from hypothesis import given
+
+from mtl.connective import godel, zadeh, lukasiewicz, product
+
+
+@given(
+    st.sampled_from([zadeh, godel, lukasiewicz, product]),
+    st.floats(min_value=0., max_value=1., width=16),
+    st.floats(min_value=0., max_value=1., width=16),
+)
+def test_fuzzy_connective_neg(con, a: float, b: float):
+    assert con.negation(0.) == 1.
+    assert con.negation(1.) == 0.
+    assert not (a <= b) or (con.negation(a) >= con.negation(b))
+
+
+@given(
+    st.sampled_from([zadeh, godel, lukasiewicz, product]),
+    st.floats(min_value=0., max_value=1., width=16),
+    st.floats(min_value=0., max_value=1., width=16),
+    st.floats(min_value=0., max_value=1., width=16),
+)
+def test_fuzzy_connective_norm(con, a: float, b: float, c: float):
+    assert con.tnorm([a, b, 0.]) == 0.
+    assert con.tnorm([a, 1.]) == a
+    assert con.tnorm([a, b]) == con.tnorm([b, a])
+    assert (not b >= c) or (con.tnorm([a, b]) >= con.tnorm([a, c]))
+    assert con.tnorm([a, b]) <= a
+
+
+@given(
+    st.sampled_from([zadeh, godel, lukasiewicz, product]),
+    st.floats(min_value=0., max_value=1., width=16),
+    st.floats(min_value=0., max_value=1., width=16),
+    st.floats(min_value=0., max_value=1., width=16),
+)
+def test_fuzzy_connective_conorm(con, a: float, b: float, c: float):
+    assert con.tconorm([a, 0.]) == a
+    assert con.tconorm([a, b, 1.]) == 1.
+    assert con.tconorm([a, b]) == con.tconorm([b, a])
+    assert (not b >= c) or (con.tconorm([a, b]) >= con.tconorm([a, c]))
+    assert con.tconorm([a, b]) >= a
+
+
+@given(
+    st.sampled_from([zadeh, godel, lukasiewicz, product]),
+    st.floats(min_value=0., max_value=1., width=16),
+    st.floats(min_value=0., max_value=1., width=16),
+    st.floats(min_value=0., max_value=1., width=16),
+)
+def test_fuzzy_connective_implication(con, a: float, b: float, c: float):
+    assert con.implication(1., a) == a
+    assert con.implication(0., b) == con.implication(a, 1.) == 1.
+    assert con.implication(a, 0.) == con.negation(a)
+    assert (not a <= b) or (con.implication(a, c) >= con.implication(b, c))
+    assert (not b <= c) or (con.implication(a, b) <= con.implication(a, c))
+    assert con.implication(a, b) >= max(con.negation(a), b)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "metric-temporal-logic"
 readme="README.md"
-version = "0.2.2"
+version = "0.3.2"
 description = "A library for manipulating and evaluating metric temporal logic."
 repository = "https://github.com/mvcisback/py-metric-temporal-logic"
 authors = ["Marcell Vazquez-Chanlatte <mvc@linux.com>"]


### PR DESCRIPTION
> Ongoing feature draft

This PR introduces changes to allow for different logic connectives to be used during signal valuation supporting fuzzy logic. (See #224)

Changelog:
- Split the definition of the `Or` and `Implies` expressions to use the corresponding connectives
- Added fuzzy and default connective definitions based on [FT-LTL][1]
- Specify selected connective on expression evaluation
- Added tests for fuzzy expressions and connectives
- Minor optimisation on interpolation to prevent full signal duplication

### WiP

#### Cleanup connectives' definition

The definition and integration of the connectives in the evaluation is unarguably quite inelegant. Advice is more than welcome to improve said definitions.

#### Quantitive evaluation test failure

The PR passes all tests, except for `test_eval_with_signal`. This is due to a change in quantitative evaluation. `True` and `False` are no longer represented as `-1` and `1` by default, but as `-inf` and `inf`. Work is ongoing to support to the previous valuation.
https://github.com/mvcisback/py-metric-temporal-logic/blob/b2f4b1efd1352eb6a7366d6d918a3525532a2e31/mtl/test_eval.py#L27-L34

#### Limit-based connective operations

Some connective operations, `product` and `lukasiewicz`, are defined such that each time instant of the interval where they apply should be considered as a distinct value for evaluation. However valuation currently only occurs at pivot points where operands change. This semantic is valid for itempotent values or operations, e.g. `max(0.1, 0.1) = 0.1`.

As an example consider the expression `phi = G[0;5](a)` with `a = [(0, 0.1)]` and `dt = 1`. Under the `product` connective, the evaluation at time 0 should consider all values of `a` in the interval: `phi[0] = 0.00001 = a[0] * a[1] * a[2] * a[3] * a[4]`. It is currently only evaluated at time 0 such that `phi[0] = 0.1`.

Possible solutions include:
- define `pow` versions of the connective operations, using both the operand value and the length of the time interval (factor)
- remove support for such connectives

[1]: https://dl.acm.org/doi/10.1145/2629606